### PR TITLE
Fixed sizing in WeekTracker component

### DIFF
--- a/workout-app/src/components/weekTracker.tsx
+++ b/workout-app/src/components/weekTracker.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 
 const WeekTracker = () => {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const [buttonClicked, setButtonClicked] = useState(false);
 
   const handleClick = () => {
@@ -11,7 +10,7 @@ const WeekTracker = () => {
   return (
     <div className="flex justify-center items-start min-h-96 p-4">
       <button
-        className={`w-${buttonClicked ? 'full' : '52'} h-[20px] px-4 py-[16px] rounded-full justify-center items-center inline-flex bg-red-700 text-white`}
+        className={`w-${buttonClicked ? 'full' : '32'} h-[20px] px-4 py-[16px] rounded-full justify-center items-center inline-flex bg-red-700 text-white`}
         onClick={handleClick}
         style={{ fontFamily: 'Impact' }}
       >


### PR DESCRIPTION
**Changes Made:**
- Modified the WeekTracker component to control the size of the button element.
- Initially set the red box to be smaller
- When the button is clicked, it expands to full width.

**How to Test:**
1. Run the application.
2. Navigate to the screen where the WeekTracker component is displayed.
3. Observe that the red box is initially smaller and displays "WEEK 16."
4. Click the button and verify that the red box expands to full width and the text changes to "WEEK 16 out of 28."